### PR TITLE
Update ui-lovelace.yaml

### DIFF
--- a/ui-lovelace.yaml
+++ b/ui-lovelace.yaml
@@ -41,7 +41,7 @@ views:
             state_image:
               not_home: /local/resources/images/lovelace/family_away_edited.jpg
               home: /local/resources/images/lovelace/family_edited.jpg
-            entity: group.away_image
+            entity: group.tristal 
           - type: entities
             entities:
               - lock.front_door


### PR DESCRIPTION
moved logic for family image from "away_image" group to "tristal" group.